### PR TITLE
Cached responses of Reseller and Customer controllers are now private

### DIFF
--- a/src/Controller/CustomerController.php
+++ b/src/Controller/CustomerController.php
@@ -83,8 +83,8 @@ class CustomerController extends AbstractController
 
             $response = new Response($json, 200, ['Content-Type' => 'application/json']);
 
-            // cache publicly for 3600 seconds
-            $response->setPublic();
+            // cache privately (we don't want other user to get this response) for 3600 seconds
+            $response->setPrivate();
             $response->setMaxAge($this->getParameter('cache_duration'));
 
             // (optional) set a custom Cache-Control directive
@@ -179,8 +179,8 @@ class CustomerController extends AbstractController
 
             $response = new Response($json, 200, ['Content-Type' => 'application/json']);
 
-            // cache publicly for 3600 seconds
-            $response->setPublic();
+            // cache privately (we don't want other user to get this response) for 3600 seconds
+            $response->setPrivate();
             $response->setMaxAge($this->getParameter('cache_duration'));
 
             // (optional) set a custom Cache-Control directive

--- a/src/Controller/ResellerController.php
+++ b/src/Controller/ResellerController.php
@@ -99,8 +99,8 @@ class ResellerController extends AbstractController
 
             $response = new Response($json, 200, ['Content-Type' => 'application/json']);
 
-            // cache publicly for 3600 seconds
-            $response->setPublic();
+            // cache privately (we don't want other user to get this response) for 3600 seconds
+            $response->setPrivate();
             $response->setMaxAge($this->getParameter('cache_duration'));
 
             // (optional) set a custom Cache-Control directive
@@ -183,8 +183,8 @@ class ResellerController extends AbstractController
 
         $response = new Response($json, 200, ['Content-Type' => 'application/json']);
 
-        // cache publicly for 3600 seconds
-        $response->setPublic();
+        // cache privately (we don't want other user to get this response) for 3600 seconds
+        $response->setPrivate();
         $response->setMaxAge($this->getParameter('cache_duration'));
 
         // (optional) set a custom Cache-Control directive


### PR DESCRIPTION
… instead of public